### PR TITLE
External MongoDB and Secrets in MongoDB

### DIFF
--- a/common/src/entity/index.ts
+++ b/common/src/entity/index.ts
@@ -41,3 +41,4 @@ export * from './dry-run-files.js';
 export * from './policy-cache-data.js';
 export * from './policy-cache.js';
 export * from './assign-entity.js';
+export * from './secret.js';

--- a/common/src/entity/secret.ts
+++ b/common/src/entity/secret.ts
@@ -5,17 +5,17 @@ import { BaseEntity } from '../models/index.js';
  * Secrets collection
  */
 @Entity()
-@Unique({ properties: ['key'], options: { partialFilterExpression: { key: { $type: 'string' }}}})
+@Unique({ properties: ['path'], options: { partialFilterExpression: { path: { $type: 'string' }}}})
 export class Secret extends BaseEntity {
     /**
      * Secret name
      */
     @Property({ nullable: true })
-    key?: string;
+    path?: string;
 
     /**
      * Secret value
      */
     @Property({ nullable: true })
-    value?: string;
+    data?: string;
 }

--- a/common/src/entity/secret.ts
+++ b/common/src/entity/secret.ts
@@ -1,0 +1,21 @@
+import { Entity, Property, Unique } from '@mikro-orm/core';
+import { BaseEntity } from '../models/index.js';
+
+/**
+ * Secrets collection
+ */
+@Entity()
+@Unique({ properties: ['key'], options: { partialFilterExpression: { key: { $type: 'string' }}}})
+export class Secret extends BaseEntity {
+    /**
+     * Secret name
+     */
+    @Property({ nullable: true })
+    key?: string;
+
+    /**
+     * Secret value
+     */
+    @Property({ nullable: true })
+    value?: string;
+}

--- a/common/src/helpers/db-helper.ts
+++ b/common/src/helpers/db-helper.ts
@@ -3,6 +3,7 @@ import { MongoDriver, MongoEntityManager, MongoEntityRepository, ObjectId } from
 import { BaseEntity } from '../models/index.js';
 import { DataBaseNamingStrategy } from './db-naming-strategy.js';
 import { GridFSBucket } from 'mongodb';
+import fixConnectionString from './fix-connection-string.js';
 
 /**
  * Common connection config
@@ -13,7 +14,7 @@ export const COMMON_CONNECTION_CONFIG: any = {
     dbName: (process.env.GUARDIAN_ENV || (process.env.HEDERA_NET !== process.env.PREUSED_HEDERA_NET)) ?
         `${process.env.GUARDIAN_ENV}_${process.env.HEDERA_NET}_${process.env.DB_DATABASE}` :
         process.env.DB_DATABASE,
-    clientUrl: `mongodb://${process.env.DB_HOST}`,
+    clientUrl: fixConnectionString(process.env.DB_HOST),
     entities: [
         'dist/entity/*.js'
     ]

--- a/common/src/helpers/fix-connection-string.ts
+++ b/common/src/helpers/fix-connection-string.ts
@@ -1,0 +1,8 @@
+/**
+ * Fix connection string
+ * @param cs Connection string
+ * @returns Fixed connection string
+ */
+export default function fixConnectionString(cs: string) {
+    return /.+\:\/\/.+/.test(cs) ? cs : `mongodb://${cs}`;
+}

--- a/common/src/secret-manager/mongodb/encryptor.ts
+++ b/common/src/secret-manager/mongodb/encryptor.ts
@@ -1,0 +1,51 @@
+import * as crypto from 'crypto';
+
+class Encryptor {
+    private readonly algorithm = 'aes-256-cbc';
+    private readonly key: Buffer | null;
+    private readonly encryptionEnabled: boolean;
+    private readonly encryptedPrefix = 'ENC:';
+    public static readonly KEYNAME = "MONGO_ENCRYPTION_KEY";
+
+    constructor() {
+        const envKey = process.env[Encryptor.KEYNAME];
+        if (!envKey) {
+            this.key = null;
+            this.encryptionEnabled = false;
+        } else {
+            this.key = crypto.scryptSync(envKey, 'salt', 32);
+            this.encryptionEnabled = true;
+        }
+    }
+
+    encrypt(text: string): string {
+        if (!this.encryptionEnabled) {
+            return text;
+        }
+        const iv = crypto.randomBytes(16);
+        const cipher = crypto.createCipheriv(this.algorithm, this.key!, iv);
+        let encrypted = cipher.update(text, 'utf8', 'base64');
+        encrypted += cipher.final('base64');
+        const salt = iv.toString('base64');
+        return this.encryptedPrefix + `${salt}~${encrypted}`;
+    }
+
+    decrypt(text: string): string {
+        if (!text.startsWith(this.encryptedPrefix)) {
+            return text;
+        }
+        if (!this.encryptionEnabled) {
+            console.warn('Attempted to decrypt, but encryption is disabled. Returning original text.');
+            return text.slice(this.encryptedPrefix.length);
+        }
+        const encryptedText = text.slice(this.encryptedPrefix.length);
+        const [salt, encrypted] = encryptedText.split('~');
+        const iv = Buffer.from(salt, 'base64');
+        const decipher = crypto.createDecipheriv(this.algorithm, this.key!, iv);
+        let decrypted = decipher.update(encrypted, 'base64', 'utf8');
+        decrypted += decipher.final('utf8');
+        return decrypted;
+    }
+}
+
+export default Encryptor;

--- a/common/src/secret-manager/mongodb/mongodb-secret-manager.ts
+++ b/common/src/secret-manager/mongodb/mongodb-secret-manager.ts
@@ -1,0 +1,67 @@
+import { SecretManagerBase } from '../secret-manager-base.js';
+import { DataBaseHelper } from '../../helpers/db-helper.js';
+import { Secret } from '../../entity/secret.js';
+import Encryptor from './encryptor.js';
+
+export class MongoDbSecretManager implements SecretManagerBase {
+
+    // Bypass DB for secrets that are stored in environment variables
+    // as these are accessed during the environment verification
+    private static secretsFromEnvironment: Record<string, any> = {
+        "secretkey/auth": {
+            "ACCESS_TOKEN_SECRET": process.env.ACCESS_TOKEN_SECRET,
+        },
+        "keys/operator": {
+            "OPERATOR_ID": process.env.OPERATOR_ID,
+            "OPERATOR_KEY": process.env.OPERATOR_KEY
+        },
+        "apikey/ipfs": {
+            "IPFS_STORAGE_API_KEY": process.env.IPFS_STORAGE_API_KEY
+        }
+    }
+    
+    public async getSecrets(path: string, _?: any): Promise<any> {
+        if (MongoDbSecretManager.secretsFromEnvironment.hasOwnProperty(path)) {
+            return MongoDbSecretManager.secretsFromEnvironment[path];
+        }
+        const helper = new DataBaseHelper(Secret);
+        const secrets = await helper.findOne({ path });
+        if (!secrets) {
+            return null;
+        }
+        return JSON.parse(new Encryptor().decrypt(secrets.data));
+    }
+
+    public async setSecrets(path: string, data: any, _?: any): Promise<void> {
+        if (MongoDbSecretManager.secretsFromEnvironment.hasOwnProperty(path)) {
+            return;
+        }
+        console.log(`MONGODB-SECRETS: Setting secret ${path}`);
+        const secret = await this.getSecrets(path);
+        const helper = new DataBaseHelper(Secret);
+        const secretData = new Encryptor().encrypt(JSON.stringify(data));
+        if (secret) {
+            console.log(`MONGODB-SECRETS: Existing secret ${path}`);
+            secret.data = secretData;
+            await helper.update({ path }, secret);
+        } else {
+            console.log(`MONGODB-SECRETS: New secret ${path}`);
+            const row = helper.create({ path, data: secretData });
+            await helper.create({ path, data: secretData });
+            await helper.save(row)
+        }
+        console.log(`MONGODB-SECRETS: Completed setting secret ${path}`);
+
+        {
+            // TEST: Verification
+            const verify = await this.getSecrets(path);
+            if (JSON.stringify(verify) !== JSON.stringify(data)) {
+                console.log('Secrets verification failed');
+                console.log('Original:', data);
+                console.log('Returned:', verify);
+                throw new Error('Secrets verification failed');
+            }
+            console.log(`MONGODB-SECRETS: VERIFIED secret ${path}`);
+        }
+    }
+}

--- a/common/src/secret-manager/mongodb/mongodb-secret-manager.ts
+++ b/common/src/secret-manager/mongodb/mongodb-secret-manager.ts
@@ -52,11 +52,12 @@ export class MongoDbSecretManager implements SecretManagerBase {
         }
         console.log(`MONGODB-SECRETS: Completed setting secret ${path}`);
 
+        // TEMP: Verify encrypt/decrypt symetry
+        if ("Y" === process.env.VERIFY_SECRETS)
         {
-            // TEST: Verification
             const verify = await this.getSecrets(path);
             if (JSON.stringify(verify) !== JSON.stringify(data)) {
-                console.log('Secrets verification failed');
+                console.log(`MONGODB-SECRETS: VERIFICATION FAILED secret ${path}`);
                 console.log('Original:', data);
                 console.log('Returned:', verify);
                 throw new Error('Secrets verification failed');

--- a/common/src/secret-manager/secret-manager-config.ts
+++ b/common/src/secret-manager/secret-manager-config.ts
@@ -25,6 +25,10 @@ export enum SecretManagerType {
    */
   AZURE = 'azure',
   /**
+   * MongoDB Secrets Manager
+   */
+  MONGODB = 'mongodb',
+  /**
    * Old style secrets
    */
   OLD_STYLE = 'oldstyle'
@@ -52,6 +56,8 @@ export class SecretManagerConfigs {
         return GcpSecretManagerConfigs.getConfigs()
       case SecretManagerType.AZURE:
         return AzureSecretManagerConfigs.getConfigs()
+      case SecretManagerType.MONGODB:
+        return
       case SecretManagerType.OLD_STYLE:
         return
       default:

--- a/common/src/secret-manager/secret-manager.ts
+++ b/common/src/secret-manager/secret-manager.ts
@@ -9,6 +9,7 @@ import { AzureSecretManager } from './azure/azure-secret-manager.js';
 import { IAzureSecretManagerConfigs } from './azure/azure-secret-manager-configs.js';
 import { IGcpSecretManagerConfigs } from './gcp/gcp-secret-manager-configs.js';
 import { GcpSecretManager } from './gcp/gcp-secret-manager.js';
+import { MongoDbSecretManager } from './mongodb/mongodb-secret-manager.js';
 
 /**
  * Class to get secret manager
@@ -62,6 +63,8 @@ export class SecretManager {
         return new GcpSecretManager(configs as IGcpSecretManagerConfigs)
       case SecretManagerType.AZURE:
         return new AzureSecretManager(configs as IAzureSecretManagerConfigs)
+      case SecretManagerType.MONGODB:
+        return new MongoDbSecretManager()
       case SecretManagerType.OLD_STYLE:
         return new OldSecretManager()
       default:

--- a/multi-build.sh
+++ b/multi-build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+docker build -t guardian-notification-service:latest -f ./notification-service/Dockerfile --platform linux/amd64,linux/arm64 .
+docker build -t guardian-logger-service:latest -f ./logger-service/Dockerfile --platform linux/amd64,linux/arm64 .
+docker build -t guardian-worker-service:latest -f ./worker-service/Dockerfile --platform linux/amd64,linux/arm64 .
+docker build -t guardian-auth-service:latest -f ./auth-service/Dockerfile.demo --platform linux/amd64,linux/arm64 .
+docker build -t guardian-api-gateway:latest -f ./api-gateway/Dockerfile.demo --platform linux/amd64,linux/arm64 .
+docker build -t guardian-policy-service:latest -f ./policy-service/Dockerfile --platform linux/amd64,linux/arm64 .
+docker build -t guardian-mrv-sender:latest -f ./mrv-sender/Dockerfile --platform linux/amd64,linux/arm64 .
+docker build -t guardian-guardian-service:latest -f ./guardian-service/Dockerfile --platform linux/amd64,linux/arm64 .
+docker build -t guardian-web-proxy:latest -f ./web-proxy/Dockerfile.demo --platform linux/amd64,linux/arm64 .
+docker build -t guardian-application-events:latest -f ./application-events/Dockerfile --platform linux/amd64,linux/arm64 .
+docker build -t guardian-topic-viewer:latest -f ./topic-viewer/Dockerfile --platform linux/amd64,linux/arm64 .


### PR DESCRIPTION
This PR contains 2 separate changes ...

### External MongoDB
This is a copy of a change already in the hashgraph repo, to allow the `DB_HOST` envvar to contain a full connection string to MongoDB so we can use an external host, use the mongodb+srv protocol, specify username and password, and other connection options.

### Store Secrets in MongoDB
Allow the `SECRET_MANAGER` envvar to be set to `MONGODB` to have secrets stored in MongoDB.

The rationale for this is that connecting to either of the recommended secrets manager options (AWS or Vault) can be complex if you're deploying outside of AWS/Azure. The option of deploying Vault locally is complex for smaller organizations without dedicated ops support.

Secrets are stored in a `secrets` collection in the database.

By default the secrets would be plain text, but can be encrypted by setting an encryption key in the `MONGO_ENCRYPTION_KEY` envvar.

Some secrets are accessed by the startup logic in various services that executes prior to establishing a connection to the database. These are picked up from the runtime environment by the `MONGODB` secrets management rather than loading them into the `secrets` table using a seeding process, as is the approach taken by other secrets handlers.